### PR TITLE
CronJob でバッチ処理を追加

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,6 @@
 export POSTGRES_USER=your_postgres_user
 export POSTGRES_PASSWORD=your_postgres_password
 export POSTGRES_DB=your_database_name
+
+# Slack Webhook URL for CronJob notifications
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -81,7 +81,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # オプション: モデルを指定（デフォルト: Claude Sonnet 4、Claude Opus 4を使用する場合はコメントを外す）
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # オプション: モデルを指定（デフォルト: Claude Sonnet 4、Claude Opus 4を使用する場合はコメントを外す）
           # model: "claude-opus-4-20250514"

--- a/batch-scripts/Dockerfile
+++ b/batch-scripts/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# 依存関係のインストール
+RUN apk add --no-cache git
+
+# go.mod と go.sum をコピー
+COPY go.mod go.sum ./
+RUN go mod download
+
+# ソースコードをコピー
+COPY send-slack-metrics.go .
+
+# ビルド
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o send-slack-metrics .
+
+# 実行用の軽量イメージ
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# ビルドしたバイナリをコピー
+COPY --from=builder /app/send-slack-metrics .
+
+# 実行権限を付与
+RUN chmod +x ./send-slack-metrics
+
+CMD ["./send-slack-metrics"]

--- a/batch-scripts/Dockerfile
+++ b/batch-scripts/Dockerfile
@@ -16,7 +16,7 @@ COPY send-slack-metrics.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o send-slack-metrics .
 
 # 実行用の軽量イメージ
-FROM alpine:latest
+FROM alpine:3.18
 
 RUN apk --no-cache add ca-certificates
 

--- a/batch-scripts/go.mod
+++ b/batch-scripts/go.mod
@@ -1,0 +1,5 @@
+module slack-metrics-batch
+
+go 1.21
+
+require github.com/lib/pq v1.10.9

--- a/batch-scripts/go.sum
+++ b/batch-scripts/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/batch-scripts/send-slack-metrics.go
+++ b/batch-scripts/send-slack-metrics.go
@@ -158,6 +158,12 @@ func sendToSlack(message *SlackMessage) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			log.Printf("Failed to read response body: %v", readErr)
+		} else {
+			log.Printf("Slack response body: %s", string(body))
+		}
 		return fmt.Errorf("Slack returned status code: %d", resp.StatusCode)
 	}
 

--- a/batch-scripts/send-slack-metrics.go
+++ b/batch-scripts/send-slack-metrics.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+type Metrics struct {
+	DBSizeMB         float64 `json:"db_size_mb"`
+	TableCount       int     `json:"table_count"`
+	ActiveConnections int     `json:"active_connections"`
+}
+
+type SlackMessage struct {
+	Text   string       `json:"text,omitempty"`
+	Blocks []SlackBlock `json:"blocks,omitempty"`
+}
+
+type SlackBlock struct {
+	Type   string                 `json:"type"`
+	Text   *SlackText             `json:"text,omitempty"`
+	Fields []SlackField           `json:"fields,omitempty"`
+}
+
+type SlackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type SlackField struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func getDBConnection() (*sql.DB, error) {
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"),
+		os.Getenv("DB_NAME"),
+		os.Getenv("DB_SSLMODE"),
+	)
+	return sql.Open("postgres", connStr)
+}
+
+func collectMetrics(db *sql.DB) (*Metrics, error) {
+	metrics := &Metrics{}
+
+	// データベースのサイズ
+	var dbSize int64
+	err := db.QueryRow("SELECT pg_database_size(current_database())").Scan(&dbSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database size: %w", err)
+	}
+	metrics.DBSizeMB = float64(dbSize) / 1024 / 1024
+
+	// テーブル数
+	err = db.QueryRow(`
+		SELECT COUNT(*) FROM information_schema.tables 
+		WHERE table_schema = 'public'
+	`).Scan(&metrics.TableCount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get table count: %w", err)
+	}
+
+	// アクティブな接続数
+	err = db.QueryRow(`
+		SELECT COUNT(*) FROM pg_stat_activity 
+		WHERE state = 'active'
+	`).Scan(&metrics.ActiveConnections)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active connections: %w", err)
+	}
+
+	return metrics, nil
+}
+
+func formatMessage(metrics *Metrics) *SlackMessage {
+	reportFormat := os.Getenv("REPORT_FORMAT")
+	metricsType := os.Getenv("METRICS_TYPE")
+	if metricsType == "" {
+		metricsType = "database"
+	}
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+
+	if reportFormat == "detailed" {
+		return &SlackMessage{
+			Blocks: []SlackBlock{
+				{
+					Type: "header",
+					Text: &SlackText{
+						Type: "plain_text",
+						Text: fmt.Sprintf("📊 %s Metrics Report", metricsType),
+					},
+				},
+				{
+					Type: "section",
+					Fields: []SlackField{
+						{
+							Type: "mrkdwn",
+							Text: fmt.Sprintf("*Timestamp:*\n%s", timestamp),
+						},
+						{
+							Type: "mrkdwn",
+							Text: fmt.Sprintf("*Database Size:*\n%.2f MB", metrics.DBSizeMB),
+						},
+						{
+							Type: "mrkdwn",
+							Text: fmt.Sprintf("*Table Count:*\n%d", metrics.TableCount),
+						},
+						{
+							Type: "mrkdwn",
+							Text: fmt.Sprintf("*Active Connections:*\n%d", metrics.ActiveConnections),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	text := fmt.Sprintf(`📊 Database Metrics Report - %s
+• Database Size: %.2f MB
+• Table Count: %d
+• Active Connections: %d`,
+		timestamp,
+		metrics.DBSizeMB,
+		metrics.TableCount,
+		metrics.ActiveConnections,
+	)
+	return &SlackMessage{Text: text}
+}
+
+func sendToSlack(message *SlackMessage) error {
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	if webhookURL == "" {
+		return fmt.Errorf("SLACK_WEBHOOK_URL is not set")
+	}
+
+	jsonData, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %w", err)
+	}
+
+	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to send to Slack: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Slack returned status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func main() {
+	log.Println("Connecting to database...")
+	db, err := getDBConnection()
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer db.Close()
+
+	log.Println("Collecting metrics...")
+	metrics, err := collectMetrics(db)
+	if err != nil {
+		log.Fatalf("Failed to collect metrics: %v", err)
+	}
+
+	log.Println("Formatting message...")
+	message := formatMessage(metrics)
+
+	log.Println("Sending to Slack...")
+	err = sendToSlack(message)
+	if err != nil {
+		log.Fatalf("Failed to send to Slack: %v", err)
+	}
+
+	log.Println("Metrics sent successfully!")
+}

--- a/deploy-cronjob.sh
+++ b/deploy-cronjob.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🚀 CronJob のデプロイを開始します..."
+
+# Docker イメージのビルド
+echo "📦 Slack メトリクスバッチのイメージをビルドしています..."
+cd batch-scripts
+docker build -t slack-metrics-batch:latest .
+cd ..
+
+# Minikubeにイメージをロード
+echo "📤 Minikubeにイメージをロードしています..."
+minikube image load slack-metrics-batch:latest
+
+# ConfigMap のデプロイ
+echo "📋 ConfigMap をデプロイしています..."
+kubectl apply -f deployments/cronjob/slack-metrics-configmap.yaml
+
+# Secret のデプロイ（環境変数から Webhook URL を取得）
+echo "🔐 Slack Secret をデプロイしています..."
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+    echo "❌ エラー: SLACK_WEBHOOK_URL 環境変数が設定されていません"
+    echo "   以下のコマンドで環境変数を設定してください:"
+    echo "   export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/YOUR/WEBHOOK/URL'"
+    exit 1
+fi
+
+# 環境変数を使用して Secret を作成
+kubectl create secret generic slack-secret \
+    --from-literal=webhook-url="$SLACK_WEBHOOK_URL" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# CronJob のデプロイ
+echo "⏰ CronJob をデプロイしています..."
+kubectl apply -f deployments/cronjob/slack-metrics-cronjob.yaml
+
+echo "✅ CronJob のデプロイが完了しました！"
+echo ""
+echo "📊 デプロイされたリソースの確認:"
+kubectl get configmap slack-metrics-config
+kubectl get secret slack-secret
+kubectl get cronjob slack-metrics-cronjob
+
+echo ""
+echo "🔍 CronJob の詳細:"
+kubectl describe cronjob slack-metrics-cronjob
+
+echo ""
+echo "💡 手動でジョブを実行するには:"
+echo "kubectl create job --from=cronjob/slack-metrics-cronjob manual-test-$(date +%s)"

--- a/deployments/cronjob/slack-metrics-configmap.yaml
+++ b/deployments/cronjob/slack-metrics-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: slack-metrics-config
+  namespace: default
+data:
+  metrics-type: "database"
+  report-format: "detailed"  # simple or detailed

--- a/deployments/cronjob/slack-metrics-cronjob.yaml
+++ b/deployments/cronjob/slack-metrics-cronjob.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: slack-metrics-cronjob
+  namespace: default
+spec:
+  schedule: "0 9 * * *"  # 毎日朝9時に実行
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: slack-metrics
+              image: slack-metrics-batch:latest
+              imagePullPolicy: Never
+              env:
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: slack-secret
+                      key: webhook-url
+                - name: DB_HOST
+                  value: postgres-headless
+                - name: DB_PORT
+                  value: "5432"
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secret
+                      key: POSTGRES_USER
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secret
+                      key: POSTGRES_PASSWORD
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secret
+                      key: POSTGRES_DB
+                - name: DB_SSLMODE
+                  value: "disable"
+                - name: METRICS_TYPE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: slack-metrics-config
+                      key: metrics-type
+                - name: REPORT_FORMAT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: slack-metrics-config
+                      key: report-format
+          restartPolicy: OnFailure

--- a/test-api-key.sh
+++ b/test-api-key.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # API キーを引数として受け取る
-API_KEY="${1:-$ANTHROPIC_API_KEY}"
+API_KEY="${1:-$CLAUDE_CODE_OAUTH_TOKEN}"
 
 if [ -z "$API_KEY" ]; then
     echo "使用方法: ./test-api-key.sh <API_KEY>"
-    echo "または環境変数 ANTHROPIC_API_KEY を設定してください"
+    echo "または環境変数 CLAUDE_CODE_OAUTH_TOKEN を設定してください"
     exit 1
 fi
 

--- a/test-cronjob.sh
+++ b/test-cronjob.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "🧪 CronJob のテストを開始します..."
+
+# Docker イメージのビルドとMinikubeへのロード
+echo "📦 Docker イメージをビルドしています..."
+cd batch-scripts
+docker build -t slack-metrics-batch:latest .
+cd ..
+
+# Minikubeにイメージをロード
+echo "📤 Minikubeにイメージをロードしています..."
+minikube image load slack-metrics-batch:latest
+
+# 手動でジョブを作成してテスト
+JOB_NAME="manual-test-$(date +%s)"
+echo "📝 テスト用ジョブ名: $JOB_NAME"
+
+# CronJob から手動でジョブを作成
+echo "🚀 CronJob から手動でジョブを作成しています..."
+kubectl create job --from=cronjob/slack-metrics-cronjob "$JOB_NAME"
+
+# ジョブの状態を監視
+echo "⏳ ジョブの実行を待っています..."
+kubectl wait --for=condition=complete --timeout=120s job/"$JOB_NAME" || {
+    echo "❌ ジョブがタイムアウトしました"
+    echo "📋 ジョブの状態:"
+    kubectl describe job "$JOB_NAME"
+    echo "📄 Pod の状態:"
+    kubectl get pods -l job-name="$JOB_NAME" -o wide
+    echo "📄 Pod のログ:"
+    kubectl logs -l job-name="$JOB_NAME" --tail=50 || echo "ログの取得に失敗しました"
+    
+    # Pod のイベントを確認
+    POD_NAME=$(kubectl get pods -l job-name="$JOB_NAME" -o jsonpath='{.items[0].metadata.name}')
+    if [ -n "$POD_NAME" ]; then
+        echo "📋 Pod のイベント:"
+        kubectl describe pod "$POD_NAME" | grep -A 10 "Events:" || true
+    fi
+    exit 1
+}
+
+echo "✅ ジョブが正常に完了しました！"
+
+# ログの確認
+echo "📄 ジョブのログ:"
+kubectl logs -l job-name="$JOB_NAME"
+
+# クリーンアップ
+echo "🧹 テスト用ジョブをクリーンアップしています..."
+kubectl delete job "$JOB_NAME"
+
+echo "✨ テストが完了しました！"


### PR DESCRIPTION
### 🎯 このPRの目的
PostgreSQLデータベースのメトリクスを定期的に収集し、Slackに通知するバッチ処理をKubernetes CronJobとして実装

### ✨ 主な変更点
- **Go言語によるSlackメトリクス送信バッチ処理**の実装
- **Kubernetes CronJob**による定期実行の設定（毎日朝9時）
- **Docker化**による環境に依存しない実行環境の構築
- **Minikube対応**のデプロイメントスクリプト
- **ConfigMap/Secret**による設定管理
- **テストスクリプト**による動作検証機能
- **Claude Code Actions**のOAuth認証への移行

### 🔧 技術的な詳細
- **言語**: Go 1.21
- **データベース**: PostgreSQL (`github.com/lib/pq` ドライバー使用)
- **コンテナ**: Alpine Linux ベースのマルチステージビルド
- **Kubernetes リソース**: CronJob, ConfigMap, Secret
- **収集メトリクス**: データベースサイズ、テーブル数、アクティブ接続数
- **通知形式**: Slack Webhook API（シンプル/詳細 フォーマット対応）

### 📊 アーキテクチャ/フロー図
```mermaid
graph TD
    A[Kubernetes CronJob<br/>毎日朝9時] --> B[Docker Container<br/>slack-metrics-batch]
    B --> C[PostgreSQL Database]
    C --> D[メトリクス収集<br/>- DB サイズ<br/>- テーブル数<br/>- アクティブ接続数]
    D --> E[Slack メッセージ作成]
    E --> F[Slack Webhook API]
    F --> G[Slack チャンネル通知]
    
    H[ConfigMap] --> B
    I[Secret] --> B
    
    subgraph "設定管理"
        H
        I
    end
    
    subgraph "実行環境"
        J[Minikube] --> A
    end
```

### 📝 その他の注意事項
- 環境変数 `SLACK_WEBHOOK_URL` の設定が必要
- PostgreSQL接続用のSecret（`postgres-secret`）が事前に存在している必要
- `imagePullPolicy: Never` によりローカルイメージを使用
- GitHub Actions ワークフローが `CLAUDE_CODE_OAUTH_TOKEN` を使用するよう更新
